### PR TITLE
⬆️ Add support for `mongodb` v4

### DIFF
--- a/lib/mongo-milestone-db.js
+++ b/lib/mongo-milestone-db.js
@@ -1,5 +1,5 @@
 const MilestoneDB = require('sharedb').MilestoneDB;
-const mongodb = require('mongodb');
+const mongodbRequire = require('./mongodb');
 
 class MongoMilestoneDB extends MilestoneDB {
   constructor(mongo, options) {
@@ -220,7 +220,10 @@ class MongoMilestoneDB extends MilestoneDB {
       });
     }
 
-    return mongodb.connect(mongo, options);
+    const mongodb = mongodbRequire.mongodb;
+    if (typeof mongodb.connect === 'function') return mongodb.connect(mongo, options);
+    const client = new mongodb.MongoClient(mongo, options);
+    return client.connect();
   }
 
   static _snapshotToDbRepresentation(snapshot) {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1,0 +1,5 @@
+const mongodb = require('mongodb');
+
+module.exports = {
+  mongodb: mongodb,
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MongoDB milestone snapshot database adapter for ShareDB",
   "main": "lib/index.js",
   "dependencies": {
-    "mongodb": "^2.2.36 || ^3.0.0",
+    "mongodb": "^2.2.36 || ^3.0.0 || ^4.0.0",
     "sharedb": "^1.0.0"
   },
   "devDependencies": {
@@ -14,6 +14,7 @@
     "mocha": "^8.2.1",
     "mongodb2": "npm:mongodb@^2.2.36",
     "mongodb3": "npm:mongodb@^3.0.0",
+    "mongodb4": "npm:mongodb@^4.0.0",
     "nyc": "^15.1.0"
   },
   "scripts": {


### PR DESCRIPTION
This change adds support for [`mongodb` v4][1]. The only [change][2]
that seems to affect us is:

 - removal of the top-level `connect()` function

[1]: https://github.com/mongodb/node-mongodb-native/releases/tag/v4.0.0
[2]: https://github.com/mongodb/node-mongodb-native/blob/4.0/docs/CHANGES_4.0.0.md