### PR TITLE
💥 BREAKING: drop `mongodb@2` support

### DIFF
--- a/lib/mongo-milestone-db.js
+++ b/lib/mongo-milestone-db.js
@@ -160,9 +160,7 @@ class MongoMilestoneDB extends MilestoneDB {
   }
 
   _db() {
-    return this._client().then(client => (MongoMilestoneDB._isLegacyMongoClient(client)
-      ? client
-      : client.db()));
+    return this._client().then(client => client.db());
   }
 
   _collection(collectionName) {
@@ -252,14 +250,6 @@ class MongoMilestoneDB extends MilestoneDB {
   static _shallowClone(object) {
     if (typeof object !== 'object') return object;
     return Object.assign({}, object);
-  }
-
-  static _isLegacyMongoClient(client) {
-    // mongodb 2.x connect returns a DB object that also implements the
-    // functionality of a client, such as `close()`. mongodb 3.x connect
-    // returns a Client without the `collection()` method
-    return typeof client.collection === 'function'
-      && typeof client.close === 'function';
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MongoDB milestone snapshot database adapter for ShareDB",
   "main": "lib/index.js",
   "dependencies": {
-    "mongodb": "^2.2.36 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+    "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
@@ -12,7 +12,6 @@
     "coveralls": "^3.1.0",
     "eslint": "^7.14.0",
     "mocha": "^8.2.1",
-    "mongodb2": "npm:mongodb@^2.2.36",
     "mongodb3": "npm:mongodb@^3.0.0",
     "mongodb4": "npm:mongodb@^4.0.0",
     "mongodb5": "npm:mongodb@^5.0.0",

--- a/test/mongo-milestone-db.js
+++ b/test/mongo-milestone-db.js
@@ -7,7 +7,6 @@ const mongodbRequire = require('../lib/mongodb');
 const MONGO_URL = process.env.TEST_MONGO_URL || 'mongodb://localhost:27017/test';
 
 [
-  'mongodb2',
   'mongodb3',
   'mongodb4',
   'mongodb5',
@@ -17,7 +16,6 @@ const MONGO_URL = process.env.TEST_MONGO_URL || 'mongodb://localhost:27017/test'
   function create(options, callback) {
     if (typeof options === 'function') {
       callback = options;
-      options = {};
     }
 
     let db;
@@ -35,9 +33,7 @@ const MONGO_URL = process.env.TEST_MONGO_URL || 'mongodb://localhost:27017/test'
         connect(MONGO_URL)
           .then((mongoConnection) => {
             mongo = mongoConnection;
-            return MongoMilestoneDB._isLegacyMongoClient(mongo)
-              ? mongo.dropDatabase()
-              : mongo.db().dropDatabase();
+            return mongo.db().dropDatabase();
           })
           .then(() => {
             shareDbCallback(null, mongo);
@@ -65,9 +61,7 @@ const MONGO_URL = process.env.TEST_MONGO_URL || 'mongodb://localhost:27017/test'
           create((error, createdDb, createdMongo) => {
             if (error) return done(error);
             db = createdDb;
-            mongo = MongoMilestoneDB._isLegacyMongoClient(createdMongo)
-              ? createdMongo
-              : createdMongo.db();
+            mongo = createdMongo.db();
             done();
           });
         });
@@ -151,9 +145,7 @@ const MONGO_URL = process.env.TEST_MONGO_URL || 'mongodb://localhost:27017/test'
           create(options, (error, createdDb, createdMongo) => {
             if (error) return done(error);
             db = createdDb;
-            mongo = MongoMilestoneDB._isLegacyMongoClient(createdMongo)
-              ? createdMongo
-              : createdMongo.db();
+            mongo = createdMongo.db();
             done();
           });
         });


### PR DESCRIPTION
The `mongodb@2` driver is not compatible with MongoDB v6. In order to add support for the latest database, we drop support for this old version of the `mongodb` driver.