### PR TITLE
💥 Use string error codes

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,56 @@
+class InvalidCollectionNameError extends Error {
+  constructor() {
+    super();
+    this.code = 'ERR_INVALID_COLLECTION_NAME';
+    this.message = 'Must provide valid collection name';
+  }
+}
+
+class InvalidIdError extends Error {
+  constructor() {
+    super();
+    this.code = 'ERR_INVALID_ID';
+    this.message = 'Must provide valid ID';
+  }
+}
+
+class InvalidSnapshotError extends Error {
+  constructor() {
+    super();
+    this.code = 'ERR_INVALID_SNAPSHOT';
+    this.message = 'Must provide valid snapshot';
+  }
+}
+
+class InvalidVersionError extends Error {
+  constructor() {
+    super();
+    this.code = 'ERR_INVALID_VERSION';
+    this.message = 'Must provide valid integer version or null';
+  }
+}
+
+class InvalidTimestampError extends Error {
+  constructor() {
+    super();
+    this.code = 'ERR_INVALID_TIMESTAMP';
+    this.message = 'Must provide valid integer timestamp or null';
+  }
+}
+
+class MongoClosedError extends Error {
+  constructor() {
+    super();
+    this.code = 'MONGO_CLOSED';
+    this.message = 'Already closed';
+  }
+}
+
+module.exports = {
+  InvalidCollectionNameError,
+  InvalidIdError,
+  InvalidSnapshotError,
+  InvalidVersionError,
+  InvalidTimestampError,
+  MongoClosedError,
+};

--- a/lib/mongo-milestone-db.js
+++ b/lib/mongo-milestone-db.js
@@ -1,5 +1,6 @@
 const MilestoneDB = require('sharedb').MilestoneDB;
 const mongodbRequire = require('./mongodb');
+const errors = require('./errors');
 
 class MongoMilestoneDB extends MilestoneDB {
   constructor(mongo, options) {
@@ -46,8 +47,8 @@ class MongoMilestoneDB extends MilestoneDB {
       };
     }
 
-    if (!collectionName) return process.nextTick(callback, new InvalidCollectionNameError());
-    if (!snapshot) return process.nextTick(callback, new InvalidSnapshotError());
+    if (!collectionName) return process.nextTick(callback, new errors.InvalidCollectionNameError());
+    if (!snapshot) return process.nextTick(callback, new errors.InvalidSnapshotError());
 
     this._saveMilestoneSnapshot(collectionName, snapshot)
       .then(() => {
@@ -88,9 +89,9 @@ class MongoMilestoneDB extends MilestoneDB {
   }
 
   _getMilestoneSnapshotByVersion(collectionName, id, version) {
-    if (!id) return Promise.reject(new InvalidIdError());
+    if (!id) return Promise.reject(new errors.InvalidIdError());
     if (!this._isValidVersion(version)) {
-      return Promise.reject(new InvalidVersionError());
+      return Promise.reject(new errors.InvalidVersionError());
     }
 
     const query = {d: id};
@@ -106,9 +107,9 @@ class MongoMilestoneDB extends MilestoneDB {
   }
 
   _getMilestoneSnapshotByTimestamp(collectionName, id, timestamp, isAfterTimestamp) {
-    if (!id) return Promise.reject(new InvalidIdError());
+    if (!id) return Promise.reject(new errors.InvalidIdError());
     if (!this._isValidTimestamp(timestamp)) {
-      return Promise.reject(new InvalidTimestampError());
+      return Promise.reject(new errors.InvalidTimestampError());
     }
 
     const limit = 1;
@@ -136,7 +137,7 @@ class MongoMilestoneDB extends MilestoneDB {
   }
 
   _getMilestoneSnapshotByQuery(collectionName, query, options) {
-    if (!collectionName) return Promise.reject(new InvalidCollectionNameError());
+    if (!collectionName) return Promise.reject(new errors.InvalidCollectionNameError());
 
     return this._collection(collectionName)
       .then(collection => collection.findOne(query, options))
@@ -153,7 +154,7 @@ class MongoMilestoneDB extends MilestoneDB {
 
   _client() {
     if (!this._mongoPromise) {
-      return Promise.reject(new MongoClosedError());
+      return Promise.reject(new errors.MongoClosedError());
     }
 
     return this._mongoPromise;
@@ -250,54 +251,6 @@ class MongoMilestoneDB extends MilestoneDB {
   static _shallowClone(object) {
     if (typeof object !== 'object') return object;
     return Object.assign({}, object);
-  }
-}
-
-class InvalidCollectionNameError extends Error {
-  constructor() {
-    super();
-    this.code = 4101;
-    this.message = 'Must provide valid collection name';
-  }
-}
-
-class InvalidIdError extends Error {
-  constructor() {
-    super();
-    this.code = 4102;
-    this.message = 'Must provide valid ID';
-  }
-}
-
-class InvalidSnapshotError extends Error {
-  constructor() {
-    super();
-    this.code = 4103;
-    this.message = 'Must provide valid snapshot';
-  }
-}
-
-class InvalidVersionError extends Error {
-  constructor() {
-    super();
-    this.code = 4104;
-    this.message = 'Must provide valid integer version or null';
-  }
-}
-
-class InvalidTimestampError extends Error {
-  constructor() {
-    super();
-    this.code = 4105;
-    this.message = 'Must provide valid integer timestamp or null';
-  }
-}
-
-class MongoClosedError extends Error {
-  constructor() {
-    super();
-    this.code = 5101;
-    this.message = 'Already closed';
   }
 }
 


### PR DESCRIPTION
This breaking change moves us from number error codes to strings to keep better-aligned with `sharedb`.

We also move error classes into their own module so that clients can check for them using `instanceof`.