### PR TITLE
⬆️ Add support for `sharedb@4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0",
-    "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0"
+    "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
The only breaking change in `sharedb@4` is dropping support for Node.js v14 (which this library has also done).