### PR TITLE
⬆️ Add support for `mongodb@6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MongoDB milestone snapshot database adapter for ShareDB",
   "main": "lib/index.js",
   "dependencies": {
-    "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0",
+    "mongodb": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
     "sharedb": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
@@ -15,6 +15,7 @@
     "mongodb3": "npm:mongodb@^3.0.0",
     "mongodb4": "npm:mongodb@^4.0.0",
     "mongodb5": "npm:mongodb@^5.0.0",
+    "mongodb6": "npm:mongodb@^6.0.0",
     "nyc": "^15.1.0"
   },
   "scripts": {

--- a/test/mongo-milestone-db.js
+++ b/test/mongo-milestone-db.js
@@ -10,6 +10,7 @@ const MONGO_URL = process.env.TEST_MONGO_URL || 'mongodb://localhost:27017/test'
   'mongodb3',
   'mongodb4',
   'mongodb5',
+  'mongodb6',
 ].forEach((driver) => {
   const mongodb = require(driver);
 


### PR DESCRIPTION
This change adds support for the latest major version bump of the `mongodb` driver: [v6][1].

None of the breaks appear to affect us, so we just update our `dependencies` and test matrix.

[1]: https://github.com/mongodb/node-mongodb-native/releases/tag/v6.0.0