### PR TITLE
👷‍♀️ Update MongoDB test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,10 @@ jobs:
         - 18
         - 20
         mongodb:
-        - 4.0
-        - 4.2
         - 4.4
         - 5.0
         - 6.0
+        - 7.0
     services:
       mongodb:
         image: mongo:${{ matrix.mongodb }}


### PR DESCRIPTION
According to the MongoDB [release schedule][1]:

 - MongoDB 4.2 is EoL this month (April 2023)
 - MongoDB 7.0 was released in August

[1]: https://www.mongodb.com/legal/support-policy/lifecycles