### PR TITLE
💚 Add `sinon` as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "mongodb5": "npm:mongodb@^5.0.0",
     "mongodb6": "npm:mongodb@^6.0.0",
     "mongodb7": "npm:mongodb@^7.0.0",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "sinon": "^22.0.0"
   },
   "scripts": {
     "lint": "node_modules/.bin/eslint --ignore-path .gitignore '**/*.js'",


### PR DESCRIPTION
`sharedb` uses this in tests, but this repo doesn't declare it as a dev dependency, so tests are failing (not sure why they passed before!).